### PR TITLE
Add dependencies for GitHub package compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ FROM tercen/runtime-r44:4.4.3-8
 #     curl-dev openssl-dev git pkgconfig
 # # Uncomment if your R packages have Rust dependencies (e.g., stringi, gifski):
 # #   cargo rust
+# # Uncomment if installing R packages from GitHub that require compilation:
+# #   build-base linux-headers libxml2-dev
 
 COPY . /operator
 WORKDIR /operator

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ If using the minimal runtime, uncomment the relevant lines in the Dockerfile and
 - `gfortran` - Fortran compiler (statistical packages, linear algebra)
 - `curl-dev openssl-dev` - HTTP/SSL support
 - `cargo rust` - Rust toolchain (some modern R packages)
+- `build-base linux-headers libxml2-dev` - Required for installing R packages from GitHub that need compilation (e.g., pamgene packages)
 
 ## Git LFS
 


### PR DESCRIPTION
## Summary

- Add `build-base`, `linux-headers`, and `libxml2-dev` to the documented dependencies for the minimal runtime option
- These are required when installing R packages from GitHub that need compilation (e.g., pamgene packages)

Based on feedback from Dora after resolving build issues with the cs_uka_operator.

## Changes

- **Dockerfile**: Added commented line for GitHub package compilation dependencies
- **README.md**: Documented the new dependencies in the common dependencies list

🤖 Generated with [Claude Code](https://claude.com/claude-code)